### PR TITLE
Convert 'retry' to string for ES compatibility

### DIFF
--- a/lib/sidekiq/logging/shared.rb
+++ b/lib/sidekiq/logging/shared.rb
@@ -37,7 +37,7 @@ module Sidekiq
 
         # Needs to map all args to strings for ElasticSearch compatibility
         payload['args'].map!(&:to_s)
-        payload['unique_args'].map!(&:to_s) if payload['unique_args']
+        payload['unique_args']&.map!(&:to_s)
 
         if payload['retry'].is_a?(Integer)
           payload['max_retries'] = payload['retry']

--- a/lib/sidekiq/logging/shared.rb
+++ b/lib/sidekiq/logging/shared.rb
@@ -37,7 +37,6 @@ module Sidekiq
 
         # Needs to map all args to strings for ElasticSearch compatibility
         payload['args'].map!(&:to_s)
-        payload['unique_args'].map!(&:to_s) if payload['unique_args']
 
         if payload['retry'].is_a?(Integer)
           payload['max_retries'] = payload['retry']

--- a/lib/sidekiq/logging/shared.rb
+++ b/lib/sidekiq/logging/shared.rb
@@ -37,7 +37,11 @@ module Sidekiq
 
         # Needs to map all args to strings for ElasticSearch compatibility
         payload['args'].map!(&:to_s)
-        payload['retry'] = payload['retry'].to_s
+
+        if payload['retry'].is_a?(Integer)
+          payload['max_retries'] = payload['retry']
+          payload['retry'] = true
+        end
 
         payload
       end

--- a/lib/sidekiq/logging/shared.rb
+++ b/lib/sidekiq/logging/shared.rb
@@ -37,6 +37,7 @@ module Sidekiq
 
         # Needs to map all args to strings for ElasticSearch compatibility
         payload['args'].map!(&:to_s)
+        payload['retry'] = payload['retry'].to_s
 
         payload
       end

--- a/lib/sidekiq/logging/shared.rb
+++ b/lib/sidekiq/logging/shared.rb
@@ -37,6 +37,7 @@ module Sidekiq
 
         # Needs to map all args to strings for ElasticSearch compatibility
         payload['args'].map!(&:to_s)
+        payload['unique_args'].map!(&:to_s) if payload['unique_args']
 
         if payload['retry'].is_a?(Integer)
           payload['max_retries'] = payload['retry']

--- a/lib/sidekiq/logging/shared.rb
+++ b/lib/sidekiq/logging/shared.rb
@@ -37,7 +37,7 @@ module Sidekiq
 
         # Needs to map all args to strings for ElasticSearch compatibility
         payload['args'].map!(&:to_s)
-        payload['unique_args']&.map!(&:to_s)
+        payload['unique_args'].map!(&:to_s) if payload['unique_args']
 
         if payload['retry'].is_a?(Integer)
           payload['max_retries'] = payload['retry']


### PR DESCRIPTION
'retry' field can contain not just integer but also false. This breaks ES compatibility.

The error I'm currently getting:
```
failed to parse [retry]
Current token (VALUE_FALSE) not numeric, can not use numeric value accessors
```