### PR TITLE
Allow all args to be filtered

### DIFF
--- a/lib/sidekiq/logging/shared.rb
+++ b/lib/sidekiq/logging/shared.rb
@@ -36,7 +36,7 @@ module Sidekiq
         end
 
         # Needs to map all args to strings for ElasticSearch compatibility
-        payload['args'].map!(&:to_s)
+        payload['args'].map!(&:to_s) if payload['args'].respond_to?(:map!)
 
         payload
       end


### PR DESCRIPTION
I was attempting to filter out all args from the log and so I set the filtered_args to 'args'. This resulted in map! being called on the string '[Filtered]'.

