### PR TITLE
Hide arguments that are encrypted

### DIFF
--- a/lib/sidekiq/logging/shared.rb
+++ b/lib/sidekiq/logging/shared.rb
@@ -1,6 +1,8 @@
 module Sidekiq
   module Logging
     module Shared
+      ENCRYPTED = '[ENCRYPTED]'.freeze
+
       def log_job(payload, started_at, exc = nil)
         # Create a copy of the payload using JSON
         # This should always be possible since Sidekiq store it in Redis
@@ -33,6 +35,11 @@ module Sidekiq
         unless filter_args.empty?
           args_filter     = Sidekiq::Logging::ArgumentFilter.new(filter_args)
           payload['args'] = args_filter.filter({ args: payload['args'] })[:args]
+        end
+
+        # If encrypt is true, the last arg is encrypted so hide it
+        if payload['encrypt']
+          payload['args'][-1] = ENCRYPTED
         end
 
         # Needs to map all args to strings for ElasticSearch compatibility

--- a/spec/factories/jobs.rb
+++ b/spec/factories/jobs.rb
@@ -18,7 +18,13 @@ FactoryGirl.define do
     queue 'default'
     jid '0afe8ddfcba21525022ce638'
     enqueued_at '2016-07-06T18:18:25.499Z'
+    encrypt false
 
     initialize_with {attributes.stringify_keys}
+    after(:build) do |job|
+      if job['encrypt']
+        job['args'][-1] = 'BAhTOhFTaWRla2lxOjpFbmMIOgdpdiIVo1mbHmnVxiOIT'
+      end
+    end
   end
 end

--- a/spec/sidekiq/logstash_spec.rb
+++ b/spec/sidekiq/logstash_spec.rb
@@ -42,4 +42,13 @@ describe Sidekiq::Logstash do
     log_job = Sidekiq::Logstash.configuration.custom_options.call(job)
     expect(log_job['test']).to eq('test')
   end
+
+  context 'when a job has encrypted arguments' do
+    let (:job) { FactoryGirl.build(:job, encrypt: true) }
+
+    it 'hides encrypted args' do
+      log_job = Sidekiq::Middleware::Server::LogstashLogging.new.log_job(job, Time.now.utc)
+      expect(log_job['args'][2]).to include('[ENCRYPTED]')
+    end
+  end
 end


### PR DESCRIPTION
Sidekiq enterprise supports [encrypting arguments](https://github.com/mperham/sidekiq/wiki/Ent-Encryption). When logging them, they are long unintelligible strings that don't provide value. This diff adds detection for when arguments are encrypted and replaces it with a string '[ENCRYPTED]'.