### PR TITLE
gemspec: Drop unused directives

### DIFF
--- a/sidekiq-logstash.gemspec
+++ b/sidekiq-logstash.gemspec
@@ -18,8 +18,6 @@ Gem::Specification.new do |spec|
   spec.license = 'MIT'
 
   spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir = 'exe'
-  spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.5.0'
 


### PR DESCRIPTION
This PR drops the `executables` config from the gemspec - this gem exposes none.