### PR TITLE
CI: use bundler-cache from ruby/setup-ruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.x
-      - name: Install dependencies
-        run: bundle install
+          ruby-version: 2.7
+          bundler-cache: true 
       - name: Run rubocop
         run: bundle exec rubocop --format progress
   build:
@@ -28,14 +27,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.5.x', '2.6.x', '2.7.x']
+        ruby: ['2.5', '2.6', '2.7']
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - name: Install dependencies
-        run: bundle install
+          bundler-cache: true
       - name: Run tests
         run: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@
 
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in sidekiq-logstash.gemspec
-
 gemspec
+
+gem 'rubocop-rake'
+gem 'rubocop-rspec'

--- a/lib/sidekiq/logging/argument_filter.rb
+++ b/lib/sidekiq/logging/argument_filter.rb
@@ -63,7 +63,7 @@ module Sidekiq
             parents.push(key) if deep_regexps
             if regexps.any? { |r| key =~ r }
               value = FILTERED
-            elsif deep_regexps && (joined = parents.join('.')) && deep_regexps.any? { |r| joined =~ r }
+            elsif deep_regexps && (joined = parents.join('.')) && deep_regexps.any? { |r| joined =~ r } # rubocop:disable Lint/DuplicateBranch
               value = FILTERED
             elsif value.is_a?(Hash)
               value = call(value, parents)
@@ -71,15 +71,15 @@ module Sidekiq
               value = value.map { |v| v.is_a?(Hash) ? call(v, parents) : v }
             elsif blocks.any?
               key = begin
-                      key.dup
-                    rescue StandardError
-                      key
-                    end
+                key.dup
+              rescue StandardError
+                key
+              end
               value = begin
-                        value.dup
-                      rescue StandardError
-                        value
-                      end
+                value.dup
+              rescue StandardError
+                value
+              end
               blocks.each { |b| b.call(key, value) }
             end
             parents.pop if deep_regexps

--- a/lib/sidekiq/logging/shared.rb
+++ b/lib/sidekiq/logging/shared.rb
@@ -128,7 +128,7 @@ module Sidekiq
       def deep_stringify!(args)
         case args
         when Hash
-          Hash[args.map { |key, value| [deep_stringify!(key), deep_stringify!(value)] }]
+          args.map { |key, value| [deep_stringify!(key), deep_stringify!(value)] }.to_h
         when Array
           args.map! { |val| deep_stringify!(val) }
         else

--- a/sidekiq-logstash.gemspec
+++ b/sidekiq-logstash.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-json_expectations', '~> 2.1.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.5'
+  spec.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
This PR uses the ruby/setup-ruby GitHub Action, instead of that other one (the old one does not have the `bundler-cache` setting).