### PR TITLE
FIX: record the original exception info when job can be retried

### DIFF
--- a/lib/sidekiq/logging/shared.rb
+++ b/lib/sidekiq/logging/shared.rb
@@ -49,6 +49,8 @@ module Sidekiq
 
         payload['message'] += ": fail: #{payload['duration']} sec"
         payload['job_status'] = 'fail'
+
+        exc = exc.cause || exc if exc.is_a? Sidekiq::JobRetry::Handled
         payload['error_message'] = exc.message
         payload['error'] = exc.class
         payload['error_backtrace'] = %('#{exc.backtrace.join("\n")}')

--- a/spec/workers/spec_worker.rb
+++ b/spec/workers/spec_worker.rb
@@ -4,6 +4,6 @@ class SpecWorker
   include Sidekiq::Worker
 
   def perform(fail = false, _params = {})
-    raise RuntimeError if fail
+    raise 'You know nothing, Jon Snow.' if fail
   end
 end


### PR DESCRIPTION
If a failed job is able to be retried, Sidekiq will

1. catch the original exception
2. append the exception message to the job and push it into retry queue
3. raise a new exception `Sidekiq::JobRetry::Skip`

when `Sidekiq::LogstashJobLogger` tries to parse the failed job by #log_job_exception,
the received exception is `Sidekiq::JobRetry::Skip` and
the recorded `error_message`, `error` and `error_backtrace` are wrong.