### PR TITLE
fix config deprecation

### DIFF
--- a/lib/sidekiq/logstash.rb
+++ b/lib/sidekiq/logstash.rb
@@ -29,7 +29,7 @@ module Sidekiq
         end
 
         # Add logstash support
-        config.options[:job_logger] = Sidekiq::LogstashJobLogger
+        config[:job_logger] = Sidekiq::LogstashJobLogger
 
         # Set custom formatter for Sidekiq logger
         config.logger.formatter = Sidekiq::Logging::LogstashFormatter.new


### PR DESCRIPTION
This fixes `config.options[:key] = value` is deprecated, use `config[:key] = value` issue