### PR TITLE
Add `error_cause` property to log message.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,9 @@ Metrics/BlockLength:
   Exclude:
     - spec/**/*.rb
 
+Metrics/ModuleLength:
+  Enabled: false 
+
 Layout/LineLength:
   Max: 120
   Exclude:

--- a/lib/sidekiq/exception_utils.rb
+++ b/lib/sidekiq/exception_utils.rb
@@ -2,25 +2,31 @@
 
 # Utility that allows us to get a hash representation of an exception
 module ExceptionUtils
-  def self.get_exception_with_cause_hash(exc, parent_backtrace = nil, max_depth_left)
-    backtrace = exc.backtrace || []
+  module_function
+
+  def get_exception_with_cause_hash(exc, parent_backtrace = nil, max_depth_left: 1)
+    error_hash = {
+      'class' => exc.class.to_s,
+      'message' => exc.message,
+      'backtrace' => backtrace_for(exc, parent_backtrace)
+    }
+
+    if (cause = exc.cause) && max_depth_left.positive?
+      # Pass the current backtrace as the parent_backtrace to the cause to shorten cause's backtrace list
+      error_hash['cause'] = get_exception_with_cause_hash(cause, exc.backtrace, max_depth_left: max_depth_left - 1)
+    end
+
+    error_hash
+  end
+
+  def backtrace_for(exception, parent_backtrace = nil)
+    backtrace = exception.backtrace || []
     if parent_backtrace
       common_lines = backtrace.reverse.zip(parent_backtrace.reverse).take_while { |a, b| a == b }
 
       backtrace = backtrace[0...-common_lines.length] if common_lines.any?
     end
 
-    error_hash = {
-      'class' => exc.class.to_s,
-      'message' => exc.message,
-      'backtrace' => backtrace
-    }
-
-    if (cause = exc.cause) && max_depth_left.positive?
-      # Pass the current backtrace as the parent_backtrace to the cause to shorten cause's backtrace list
-      error_hash['cause'] = get_exception_with_cause_hash(cause, exc.backtrace, max_depth_left - 1)
-    end
-
-    error_hash
+    backtrace
   end
 end

--- a/lib/sidekiq/logging/shared.rb
+++ b/lib/sidekiq/logging/shared.rb
@@ -54,7 +54,9 @@ module Sidekiq
 
         config = Sidekiq::Logstash.configuration
         if config.log_job_exception_with_causes
-          payload['error'] = ExceptionUtils.get_exception_with_cause_hash(exc, max_depth_left: config.causes_logging_max_depth)
+          payload['error'] = ExceptionUtils.get_exception_with_cause_hash(
+            exc, max_depth_left: config.causes_logging_max_depth
+          )
         else
           exc = exc.cause || exc if exc.is_a? Sidekiq::JobRetry::Handled
           payload['error_message'] = exc.message

--- a/spec/sidekiq/logstash_spec.rb
+++ b/spec/sidekiq/logstash_spec.rb
@@ -120,9 +120,15 @@ describe Sidekiq::Logstash do
     it 'logs the exception with job retry' do
       expect { process(SpecWorker, [true]) }.to raise_error(RuntimeError)
 
-      expect(log_message['error_message']).to eq('You know nothing, Jon Snow.')
       expect(log_message['error']).to eq('RuntimeError')
+      expect(log_message['error_message']).to eq('You know nothing, Jon Snow.')
       expect(log_message['error_backtrace'].split("\n").first).to include('workers/spec_worker.rb:')
+      expect(log_message['error_cause']).to match(
+        hash_including(
+          'class' => 'RuntimeError',
+          'message' => 'Error rescuing error'
+        )
+      )
     end
 
     it 'logs the exception without job retry' do
@@ -130,9 +136,15 @@ describe Sidekiq::Logstash do
 
       expect { process(SpecWorker, [true]) }.to raise_error(RuntimeError)
 
-      expect(log_message['error_message']).to eq('You know nothing, Jon Snow.')
       expect(log_message['error']).to eq('RuntimeError')
+      expect(log_message['error_message']).to eq('You know nothing, Jon Snow.')
       expect(log_message['error_backtrace'].split("\n").first).to include('workers/spec_worker.rb:')
+      expect(log_message['error_cause']).to match(
+        hash_including(
+          'class' => 'RuntimeError',
+          'message' => 'Error rescuing error'
+        )
+      )
     end
 
     context 'log_job_exception_with_causes enabled' do


### PR DESCRIPTION
## Summary

Follow up from #38 to add an `error_cause` to the default log message as well as this can be pretty useful!